### PR TITLE
feat: 增加在创建新文章的弹框里添加自定义字段的输入

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1650,7 +1650,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexohub"
-version = "3.6.0"
+version = "3.6.1"
 dependencies = [
  "encoding_rs",
  "log",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1189,6 +1189,7 @@ export default function Home() {
     categories: string[];
     excerpt?: string;
     template?: string;
+    customFields?: Record<string, string>;
   }) => {
     setIsLoading(true);
     try {
@@ -1221,8 +1222,8 @@ export default function Home() {
           variant: 'success',
         });
         
-        // 如果有额外的标签、分类或摘要，需要更新文件
-        if (postData.tags.length > 0 || postData.categories.length > 0 || postData.excerpt) {
+        // 如果有额外的标签、分类、摘要或自定义字段，需要更新文件
+        if (postData.tags.length > 0 || postData.categories.length > 0 || postData.excerpt || postData.customFields) {
           await updatePostFrontMatter(postData);
         }
 
@@ -1267,6 +1268,7 @@ export default function Home() {
     tags: string[];
     categories: string[];
     excerpt?: string;
+    customFields?: Record<string, string>;
   }) => {
     try {
       const ipcRenderer = await getIpcRenderer();
@@ -1306,6 +1308,22 @@ export default function Home() {
         // 添加摘要
         if (postData.excerpt) {
           frontMatter += `\nexcerpt: "${postData.excerpt}"`;
+        }
+
+        // 添加自定义字段
+        if (postData.customFields) {
+          Object.entries(postData.customFields).forEach(([key, value]) => {
+            // Check if the field already exists in front matter
+            const fieldRegex = new RegExp(`^${key}:\\s*(.*)$`, 'm');
+            const fieldMatch = frontMatter.match(fieldRegex);
+            if (fieldMatch) {
+              // Replace existing field value
+              frontMatter = frontMatter.replace(fieldRegex, `${key}: ${value}`);
+            } else {
+              // Add new field
+              frontMatter += `\n${key}: ${value}`;
+            }
+          });
         }
 
         // 重新构建文件内容

--- a/src/components/create-post-dialog.tsx
+++ b/src/components/create-post-dialog.tsx
@@ -6,7 +6,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
-import { X, ChevronDown, HelpCircle } from 'lucide-react';
+import { X, ChevronDown, HelpCircle, Plus } from 'lucide-react';
 import { Language, getTexts } from '@/utils/i18n';
 import { isDesktopApp, getIpcRenderer } from '@/lib/desktop-api';
 
@@ -44,6 +44,8 @@ export function CreatePostDialog({ open, onOpenChange, onConfirm, isLoading = fa
   const [showTemplateDropdown, setShowTemplateDropdown] = useState(false);
   const [customFields, setCustomFields] = useState<{key: string; defaultValue: string}[]>([]);
   const [customFieldValues, setCustomFieldValues] = useState<Record<string, string>>({});
+  const [enableUserCustomFields, setEnableUserCustomFields] = useState(false);
+  const [userCustomFields, setUserCustomFields] = useState<{key: string; value: string; persist: boolean}[]>([]);
   const tagDropdownRef = useRef<HTMLDivElement>(null);
   const categoryDropdownRef = useRef<HTMLDivElement>(null);
   const templateDropdownRef = useRef<HTMLDivElement>(null);
@@ -106,13 +108,22 @@ export function CreatePostDialog({ open, onOpenChange, onConfirm, isLoading = fa
       return;
     }
 
-    // Collect non-empty custom field values
-    const filledCustomFields: Record<string, string> = {};
+    // Collect non-empty custom field values from template fields
+    const allCustomFields: Record<string, string> = {};
     Object.entries(customFieldValues).forEach(([key, value]) => {
       if (value.trim()) {
-        filledCustomFields[key] = value.trim();
+        allCustomFields[key] = value.trim();
       }
     });
+
+    // Merge user-defined custom fields (override template fields on conflict)
+    if (enableUserCustomFields) {
+      userCustomFields.forEach(f => {
+        if (f.key.trim() && f.value.trim()) {
+          allCustomFields[f.key.trim()] = f.value.trim();
+        }
+      });
+    }
 
     onConfirm({
       title: title.trim(),
@@ -120,8 +131,18 @@ export function CreatePostDialog({ open, onOpenChange, onConfirm, isLoading = fa
       categories,
       excerpt: excerpt.trim() || undefined,
       template: useCustomTemplate ? selectedTemplate : undefined,
-      customFields: Object.keys(filledCustomFields).length > 0 ? filledCustomFields : undefined
+      customFields: Object.keys(allCustomFields).length > 0 ? allCustomFields : undefined
     });
+
+    // Save persisted custom fields to localStorage
+    if (enableUserCustomFields) {
+      const toPersist = userCustomFields
+        .filter(f => f.persist && f.key.trim() && f.value.trim())
+        .map(f => ({ key: f.key.trim(), value: f.value.trim() }));
+      localStorage.setItem('persisted-custom-frontmatter', JSON.stringify(toPersist));
+    } else {
+      localStorage.removeItem('persisted-custom-frontmatter');
+    }
 
     // 重置表单
     setTitle('');
@@ -133,6 +154,8 @@ export function CreatePostDialog({ open, onOpenChange, onConfirm, isLoading = fa
     setUseCustomTemplate(false);
     setSelectedTemplate('post');
     setCustomFieldValues({});
+    setEnableUserCustomFields(false);
+    setUserCustomFields([]);
   };
 
   // Built-in fields that are already handled by dedicated inputs
@@ -229,6 +252,24 @@ export function CreatePostDialog({ open, onOpenChange, onConfirm, isLoading = fa
     }
   }, [open, hexoPath, useCustomTemplate, selectedTemplate]);
 
+  // Load persisted custom front-matter fields from localStorage
+  useEffect(() => {
+    if (open) {
+      try {
+        const stored = localStorage.getItem('persisted-custom-frontmatter');
+        if (stored) {
+          const persisted: {key: string; value: string}[] = JSON.parse(stored);
+          if (persisted.length > 0) {
+            setEnableUserCustomFields(true);
+            setUserCustomFields(persisted.map(f => ({ key: f.key, value: f.value, persist: true })));
+          }
+        }
+      } catch (e) {
+        console.error('读取持久化自定义字段失败:', e);
+      }
+    }
+  }, [open]);
+
   // 点击外部关闭下拉菜单
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -260,6 +301,8 @@ export function CreatePostDialog({ open, onOpenChange, onConfirm, isLoading = fa
     setUseCustomTemplate(false);
     setSelectedTemplate('post');
     setCustomFieldValues({});
+    setEnableUserCustomFields(false);
+    setUserCustomFields([]);
     onOpenChange(false);
   };
 
@@ -521,6 +564,93 @@ export function CreatePostDialog({ open, onOpenChange, onConfirm, isLoading = fa
                     <ChevronDown className="h-4 w-4" />
                   </Button>
                 </div>
+              </div>
+            )}
+          </div>
+
+          {/* 自定义 Front-Matter 字段 */}
+          <div className="space-y-2">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="enable-user-custom-fields"
+                checked={enableUserCustomFields}
+                onCheckedChange={(checked) => {
+                  setEnableUserCustomFields(!!checked);
+                  if (!checked) {
+                    setUserCustomFields([]);
+                  }
+                }}
+                disabled={isLoading}
+              />
+              <Label htmlFor="enable-user-custom-fields">{texts.customFrontMatter}</Label>
+            </div>
+
+            {enableUserCustomFields && (
+              <div className="space-y-3 ml-6">
+                {userCustomFields.map((field, index) => (
+                  <div key={index} className="flex items-center gap-2">
+                    <Input
+                      value={field.key}
+                      onChange={(e) => {
+                        const newFields = [...userCustomFields];
+                        newFields[index] = { ...newFields[index], key: e.target.value };
+                        setUserCustomFields(newFields);
+                      }}
+                      placeholder={texts.fieldName}
+                      disabled={isLoading}
+                      className="flex-1"
+                    />
+                    <Input
+                      value={field.value}
+                      onChange={(e) => {
+                        const newFields = [...userCustomFields];
+                        newFields[index] = { ...newFields[index], value: e.target.value };
+                        setUserCustomFields(newFields);
+                      }}
+                      placeholder={texts.fieldValue}
+                      disabled={isLoading}
+                      className="flex-1"
+                    />
+                    <div className="flex items-center space-x-1 shrink-0">
+                      <Checkbox
+                        id={`persist-field-${index}`}
+                        checked={field.persist}
+                        onCheckedChange={(checked) => {
+                          const newFields = [...userCustomFields];
+                          newFields[index] = { ...newFields[index], persist: !!checked };
+                          setUserCustomFields(newFields);
+                        }}
+                        disabled={isLoading}
+                      />
+                      <Label htmlFor={`persist-field-${index}`} className="text-xs whitespace-nowrap">{texts.persistField}</Label>
+                    </div>
+                    <button
+                      type="button"
+                      className="shrink-0 rounded-full p-1 hover:bg-gray-200 dark:hover:bg-gray-700"
+                      onClick={() => {
+                        setUserCustomFields(userCustomFields.filter((_, i) => i !== index));
+                      }}
+                    >
+                      <X className="w-4 h-4" />
+                    </button>
+                  </div>
+                ))}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setUserCustomFields([...userCustomFields, { key: '', value: '', persist: false }]);
+                  }}
+                  disabled={isLoading}
+                  className="flex items-center gap-1"
+                >
+                  <Plus className="w-4 h-4" />
+                  {texts.addCustomField}
+                </Button>
+                <p className="text-xs text-gray-400 dark:text-gray-500">
+                  * {texts.persistFieldHint}
+                </p>
               </div>
             )}
           </div>

--- a/src/components/create-post-dialog.tsx
+++ b/src/components/create-post-dialog.tsx
@@ -19,6 +19,7 @@ interface CreatePostDialogProps {
     categories: string[];
     excerpt?: string;
     template?: string;
+    customFields?: Record<string, string>;
   }) => void;
   isLoading?: boolean;
   availableTags?: string[];
@@ -41,6 +42,8 @@ export function CreatePostDialog({ open, onOpenChange, onConfirm, isLoading = fa
   const [availableTemplates, setAvailableTemplates] = useState<string[]>([]);
   const [selectedTemplate, setSelectedTemplate] = useState('post');
   const [showTemplateDropdown, setShowTemplateDropdown] = useState(false);
+  const [customFields, setCustomFields] = useState<{key: string; defaultValue: string}[]>([]);
+  const [customFieldValues, setCustomFieldValues] = useState<Record<string, string>>({});
   const tagDropdownRef = useRef<HTMLDivElement>(null);
   const categoryDropdownRef = useRef<HTMLDivElement>(null);
   const templateDropdownRef = useRef<HTMLDivElement>(null);
@@ -103,12 +106,21 @@ export function CreatePostDialog({ open, onOpenChange, onConfirm, isLoading = fa
       return;
     }
 
+    // Collect non-empty custom field values
+    const filledCustomFields: Record<string, string> = {};
+    Object.entries(customFieldValues).forEach(([key, value]) => {
+      if (value.trim()) {
+        filledCustomFields[key] = value.trim();
+      }
+    });
+
     onConfirm({
       title: title.trim(),
       tags,
       categories,
       excerpt: excerpt.trim() || undefined,
-      template: useCustomTemplate ? selectedTemplate : undefined
+      template: useCustomTemplate ? selectedTemplate : undefined,
+      customFields: Object.keys(filledCustomFields).length > 0 ? filledCustomFields : undefined
     });
 
     // 重置表单
@@ -120,6 +132,61 @@ export function CreatePostDialog({ open, onOpenChange, onConfirm, isLoading = fa
     setCategoryInput('');
     setUseCustomTemplate(false);
     setSelectedTemplate('post');
+    setCustomFieldValues({});
+  };
+
+  // Built-in fields that are already handled by dedicated inputs
+  const BUILTIN_FIELDS = ['title', 'date', 'tags', 'categories', 'excerpt'];
+
+  // Parse front matter from template content to extract custom fields
+  const parseTemplateFields = (content: string) => {
+    const frontMatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!frontMatterMatch) return [];
+
+    const frontMatter = frontMatterMatch[1];
+    const fields: {key: string; defaultValue: string}[] = [];
+
+    const lines = frontMatter.split('\n');
+    for (const line of lines) {
+      // Match simple key: value pairs (skip list items like "  - xxx")
+      const match = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*):\s*(.*)$/);
+      if (match) {
+        const key = match[1];
+        const value = match[2].trim();
+        if (!BUILTIN_FIELDS.includes(key)) {
+          fields.push({ key, defaultValue: value });
+        }
+      }
+    }
+    return fields;
+  };
+
+  // Load template content and extract custom fields
+  const loadTemplateFields = async (templateName: string) => {
+    if (!hexoPath || !isDesktopApp()) return;
+
+    try {
+      const ipcRenderer = await getIpcRenderer();
+      const templatePath = `${hexoPath}/scaffolds/${templateName}.md`;
+      const content = await ipcRenderer.invoke('read-file', templatePath);
+      if (content) {
+        const fields = parseTemplateFields(content);
+        setCustomFields(fields);
+        // Initialize custom field values with defaults
+        const defaults: Record<string, string> = {};
+        fields.forEach(f => {
+          // Don't use template placeholders like {{ title }} as defaults
+          if (f.defaultValue && !f.defaultValue.match(/\{\{.*\}\}/)) {
+            defaults[f.key] = f.defaultValue;
+          } else {
+            defaults[f.key] = '';
+          }
+        });
+        setCustomFieldValues(defaults);
+      }
+    } catch (error) {
+      console.error('读取模板内容失败:', error);
+    }
   };
 
   // 获取可用模板
@@ -154,6 +221,14 @@ export function CreatePostDialog({ open, onOpenChange, onConfirm, isLoading = fa
     }
   }, [open, hexoPath]);
 
+  // Load custom fields from the selected template (default: post)
+  useEffect(() => {
+    if (open && hexoPath) {
+      const templateToLoad = useCustomTemplate ? selectedTemplate : 'post';
+      loadTemplateFields(templateToLoad);
+    }
+  }, [open, hexoPath, useCustomTemplate, selectedTemplate]);
+
   // 点击外部关闭下拉菜单
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -184,6 +259,7 @@ export function CreatePostDialog({ open, onOpenChange, onConfirm, isLoading = fa
     setCategoryInput('');
     setUseCustomTemplate(false);
     setSelectedTemplate('post');
+    setCustomFieldValues({});
     onOpenChange(false);
   };
 
@@ -353,6 +429,27 @@ export function CreatePostDialog({ open, onOpenChange, onConfirm, isLoading = fa
               rows={3}
             />
           </div>
+
+          {/* 自定义字段 (from scaffolds template) */}
+          {customFields.length > 0 && (
+            <div className="space-y-3">
+              <Label className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                {language === 'zh' ? '模板自定义字段' : 'Template Custom Fields'}
+              </Label>
+              {customFields.map((field) => (
+                <div key={field.key} className="space-y-1">
+                  <Label htmlFor={`custom-${field.key}`} className="text-sm">{field.key}</Label>
+                  <Input
+                    id={`custom-${field.key}`}
+                    value={customFieldValues[field.key] || ''}
+                    onChange={(e) => setCustomFieldValues(prev => ({ ...prev, [field.key]: e.target.value }))}
+                    placeholder={field.defaultValue || `${language === 'zh' ? '请输入' : 'Enter'} ${field.key}`}
+                    disabled={isLoading}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
 
           {/* 模板选项 */}
           <div className="space-y-2">

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -169,6 +169,12 @@ export interface I18nTexts {
   useCustomTemplate: string;
   selectTemplate: string;
   learnMoreAboutTemplates: string;
+  customFrontMatter: string;
+  fieldName: string;
+  fieldValue: string;
+  persistField: string;
+  persistFieldHint: string;
+  addCustomField: string;
 
   // 操作按钮
   saveArticle: string;
@@ -625,6 +631,12 @@ console.log('Hello, Hexo!');
     useCustomTemplate: '使用自定义模板',
     selectTemplate: '选择模板',
     learnMoreAboutTemplates: '了解更多关于模板的信息',
+    customFrontMatter: '添加自定义 Front-Matter 字段',
+    fieldName: '字段名',
+    fieldValue: '字段值',
+    persistField: '持久化',
+    persistFieldHint: '勾选后以后新建文章都会默认添加该字段',
+    addCustomField: '添加字段',
 
     // 操作按钮
     saveArticle: '保存文章',
@@ -1080,6 +1092,12 @@ console.log('Hello, Hexo!');
     useCustomTemplate: 'Use Custom Template',
     selectTemplate: 'Select Template',
     learnMoreAboutTemplates: 'Learn more about templates',
+    customFrontMatter: 'Add Custom Front-Matter Fields',
+    fieldName: 'Field Name',
+    fieldValue: 'Field Value',
+    persistField: 'Persist',
+    persistFieldHint: 'When checked, this field will be added to all new articles by default',
+    addCustomField: 'Add Field',
 
     // 操作按钮
     saveArticle: 'Save Article',


### PR DESCRIPTION
### 这是关于什么？

自己的 Hexo 博客 post.md 有一些自定义的字段，目前每次在创建的时候都需要手动跳到内部进行内容输入，比较麻烦，希望在创建面板直接增加输入框。

在创建新文章弹框中，动态读取 `scaffolds` 模板文件的自定义字段，自动生成对应输入框，并在提交时将值写入文章的 front matter。

实现效果：
step1: 自己的模板文件添加自定义字段
<img width="1378" height="514" alt="header" src="https://github.com/user-attachments/assets/65c8ef06-e3ca-4b76-af8b-a9fd36e1d3ae" />

step2: 输入框里面有新增字段
<img width="1002" height="1374" alt="input" src="https://github.com/user-attachments/assets/4876f9fd-35e0-4584-9264-279d486393ae" />

### 实现

1. 弹框打开时，读取 `scaffolds/{模板名}.md`，用正则解析 front matter 中的所有字段。
2. 过滤掉内置字段（title / date / tags / categories / excerpt），剩余字段动态渲染为输入框。
3. 用户提交时，将自定义字段的非空值以 `Record<string, string>` 形式随 `onConfirm` 回调传出。
4. `hexo new` 创建文章后，在 `updatePostFrontMatter` 中遍历自定义字段写入 front matter。


### 最后

- 自定义字段目前仅支持简单的 `key: value` 单行格式，不支持嵌套对象或数组类型。
- 若模板中字段带有默认值（如 `cover: default.png`），当前实现会将默认值显示在输入框的 placeholder 中，用户留空则保留模板原始默认值。